### PR TITLE
Added recursive-include to MANIFEST because submodules were excluded …

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,3 +9,4 @@ recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 
 recursive-include docs *.rst conf.py Makefile make.bat
+recursive-include graphene_custom_directives *


### PR DESCRIPTION
…from dist tarball.  This should make it possible to run `python setup.py sdist bdist_wheel upload`.